### PR TITLE
Add AEM Importer tooling for dickssportinggoods.com migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-json": "3.1.0",
         "eslint-plugin-secure-coding": "^3.1.3",
-        "eslint-plugin-sonarjs": "^3.0.7",
+        "eslint-plugin-sonarjs": "^4.0.2",
         "eslint-plugin-xwalk": "github:adobe-rnd/eslint-plugin-xwalk#v0.1.3",
         "get-tsconfig": "^4.13.6",
         "globals": "^17.3.0",
@@ -662,29 +662,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2198,38 +2175,63 @@
       }
     },
     "node_modules/eslint-plugin-sonarjs": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-3.0.7.tgz",
-      "integrity": "sha512-62jB20krIPvcwBLAyG3VVKa2ce2j2lL1yCb8Y0ylMRR/dLvCCTiQx8gQbXb+G81k1alPZ2/I3muZinqWQdBbzw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.2.tgz",
+      "integrity": "sha512-BTcT1zr1iTbmJtVlcesISwnXzh+9uhf9LEOr+RRNf4kR8xA0HQTPft4oiyOCzCOGKkpSJxjR8ZYF6H7VPyplyw==",
       "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
-        "@eslint-community/regexpp": "4.12.2",
-        "builtin-modules": "3.3.0",
-        "bytes": "3.1.2",
-        "functional-red-black-tree": "1.0.1",
-        "jsx-ast-utils-x": "0.1.0",
-        "lodash.merge": "4.6.2",
-        "minimatch": "10.1.2",
-        "scslre": "0.3.0",
-        "semver": "7.7.4",
+        "@eslint-community/regexpp": "^4.12.2",
+        "builtin-modules": "^3.3.0",
+        "bytes": "^3.1.2",
+        "functional-red-black-tree": "^1.0.1",
+        "globals": "^17.4.0",
+        "jsx-ast-utils-x": "^0.1.0",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^10.2.4",
+        "scslre": "^0.3.0",
+        "semver": "^7.7.4",
+        "ts-api-utils": "^2.4.0",
         "typescript": ">=5"
       },
       "peerDependencies": {
-        "eslint": "^8.0.0 || ^9.0.0"
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
-      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2562,10 +2564,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-json": "3.1.0",
     "eslint-plugin-secure-coding": "^3.1.3",
-    "eslint-plugin-sonarjs": "^3.0.7",
+    "eslint-plugin-sonarjs": "^4.0.2",
     "eslint-plugin-xwalk": "github:adobe-rnd/eslint-plugin-xwalk#v0.1.3",
     "get-tsconfig": "^4.13.6",
     "globals": "^17.3.0",

--- a/tools/importer/MIGRATION-PLAN-DSG.md
+++ b/tools/importer/MIGRATION-PLAN-DSG.md
@@ -1,0 +1,125 @@
+# Migration Plan: dickssportinggoods.com → aemcoder.adobe.io
+
+This document outlines the plan to migrate [Dick's Sporting Goods](https://www.dickssportinggoods.com/) into AEM Edge Delivery Services (EDS) / Document Authoring using the AEM bulk import tool and local importer tooling in this repo.
+
+## Goals
+
+- Add dickssportinggoods.com as a source for bulk import into the project (aemcoder.adobe.io / Document Authoring).
+- Provide reusable **import.js** and supporting **transformers** and **parsers** in `tools/importer/` so bulk imports can be run from your local system (AEM Importer UI or `aem import`) with accurate, repeatable conversion.
+- Distill landing page structure, blocks, and existing tooling into a single, maintainable import pipeline.
+
+## Prerequisites (from AGENTS.md and skills)
+
+1. **Design system first**  
+   Run design extraction (e.g. [get-general-styling](.agents/skills/get-general-styling/SKILL.md) or [design-system-extractor](.agents/skills/design-system-extractor/SKILL.md)) on the source site **before** bulk page import so `styles/styles.css` and `styles/fonts.css` match the brand. Migrated pages will then render against the correct foundation.
+
+2. **AEM / importer setup**  
+   - Project on Edge Delivery (e.g. aemcoder.adobe.io).  
+   - Local: `aem import` (or use [DA Import](https://da.live/apps/import) / [Bulk](https://da.live/apps/bulk)).  
+   - Import runs in browser; only Chrome-based browsers supported.  
+   - `tools/importer/import.js` is the single transformation file loaded by the importer (no build step).
+
+3. **URL list**  
+   - For bulk: paste URLs (one per line) in the Bulk tool, or use the importer’s Crawl tool (sitemap/robots.txt or crawl) and filter by pathname if needed.  
+   - Optional: use `tools/importer/url-list.txt` (or similar) to maintain a curated list; paste into Bulk when running.
+
+## Phases
+
+### Phase 1: Design and URL strategy
+
+| Step | Action |
+|------|--------|
+| 1.1 | Run design extraction on https://www.dickssportinggoods.com/ (and optionally key templates). Output: tokens, colors, typography, spacing → map into `styles/styles.css` and `styles/fonts.css`. |
+| 1.2 | Decide scope: landing only, landing + category, or full site. Use Crawl or sitemap to get URL list; filter by pathname if needed. |
+| 1.3 | Inspect landing (and 1–2 representative pages) in DevTools: identify `main`, header, footer, hero, nav, product grids, CTAs, and any recurring blocks. Document selectors in `tools/importer/config.js` (or inlined in `import.js`). |
+
+### Phase 2: Import pipeline (this repo)
+
+| Step | Action |
+|------|--------|
+| 2.1 | **import.js** in `tools/importer/import.js`: implement `transform()` (and optionally `generateDocumentPath`) per [importer guidelines](https://github.com/adobe/helix-importer-ui/blob/main/importer-guidelines.md). Return `[{ element, path, report? }]` for each document. Use `WebImporter.FileUtils.sanitizePath()` for paths. |
+| 2.2 | **Page transformers**: strip header/footer/nav, keep `main` (or equivalent), ensure first heading is H1, convert background images to `<img>`, create metadata block from `<title>` and `<meta>`. Logic lives in `import.js` (and is mirrored in `page-transformers.js` for reference/Node). |
+| 2.3 | **Block parser**: map DOM regions to EDS blocks (Hero, Cards, Accordion, Columns, etc.) by creating HTML tables in the form the importer expects (see helix-importer Blocks/DOMUtils). Block table format is documented in `block-parser.js`. |
+| 2.4 | Tune selectors and block mapping for DSG (e.g. hero banner, promos, product grids) and add any DSG-specific rules in `import.js`. |
+
+### Phase 3: Validate and bulk run
+
+| Step | Action |
+|------|--------|
+| 3.1 | **Single-page test**: In Import Workbench, run import for the DSG landing URL. Confirm structure (sections, blocks, metadata) and preview (HTML/Markdown/docx). Iterate on `import.js` (hot-reload in Workbench). |
+| 3.2 | Test 2–3 more URLs (e.g. category, PDP) and adjust rules if needed. |
+| 3.3 | **Bulk**: Paste URL list into Import – Bulk. Run import (note: `import.js` is not reloaded during bulk). Download report (XLSX) and fix any failing URLs or path issues. |
+| 3.4 | For DA: drag-and-drop or use DA Import with the same project/repo; ensure CORS allows `https://da.live` if using DA Import. |
+
+### Phase 4: Post-import
+
+| Step | Action |
+|------|--------|
+| 4.1 | Use import report for redirect mapping (old URL → new path) if paths were changed. |
+| 4.2 | Preview/publish from DA or AEM; run PageSpeed and fix any issues. |
+| 4.3 | Optionally add block library sheet in DA and configure aemcoder to point at your blocks.json per `tools/library-pages.md`. |
+
+## Tooling in this repo
+
+| Asset | Purpose |
+|-------|--------|
+| **tools/importer/import.js** | Main entry for AEM Importer. Exports `transform()` (and optionally `generateDocumentPath`). Contains DSG-specific cleanup, block creation, and path generation. Uses global `WebImporter` (provided by importer UI). |
+| **tools/importer/page-transformers.js** | Reusable DOM transform helpers (strip nav/footer, extract main, metadata, hero, sections). Kept in sync with logic used inside `import.js` for reference or for use in a Node-based pipeline. |
+| **tools/importer/block-parser.js** | Helpers and documentation for building EDS block tables (Hero, Cards, Accordion, Columns, Metadata, etc.). Defines the cell layout expected by the importer → Markdown → docx/HTML. |
+| **tools/importer/config.js** | DSG selectors and options (main, header, footer, hero, product grid, etc.). Canonical place for selectors; `import.js` inlines or references the same values. |
+| **tools/importer/MIGRATION-PLAN-DSG.md** | This plan. |
+| **tools/importer/README.md** | How to run the importer locally and customize for DSG or other sites. |
+
+## Block mapping (EDS ↔ import tables)
+
+Importer converts blocks to **HTML tables**; the first row is the block name, following rows are content. Our blocks and their expected authoring structure:
+
+| EDS block | Import table shape | Notes |
+|-----------|---------------------|--------|
+| **Metadata** | `WebImporter.Blocks.getMetadataBlock(document, meta)` or custom table with Title, Description, Image, etc. | Prepend to main. |
+| **Hero** | 1 row: block name "Hero"; 2nd row: heading + picture (or image). | First visual section. |
+| **Cards** | "Cards" + rows of cells (image, title, copy, link). | Product grids, promos. |
+| **Accordion** | "Accordion" + rows: label, body per item. | FAQs, details. |
+| **Columns** | "Columns" + one row per column content. | Multi-column layout. |
+| **Section break** | `<hr>` in DOM → `---` in Markdown. | New section. |
+
+Block structure in the repo: `blocks/{blockname}/{blockname}.js` + `.css`; decorator expects default content (e.g. table → divs). Import produces that default content via these tables.
+
+## Running the importer locally
+
+1. **CLI**  
+   From project root:
+   ```bash
+   npx -y @adobe/aem-cli import
+   ```
+   Or with custom headers (e.g. auth):
+   ```bash
+   aem import --headers-file ./tools/importer/headers.json
+   ```
+   Opens Importer UI (e.g. http://localhost:3001/...). Choose Document Authoring (or AEM Authoring). Select output (Save as docx, Save HTML for DA, etc.).
+
+2. **Single-page (Workbench)**  
+   Paste one URL (e.g. `https://www.dickssportinggoods.com/`). Click import. Adjust `tools/importer/import.js` and save; import re-runs automatically.
+
+3. **Bulk**  
+   Paste many URLs (one per line). Run import. No hot-reload of `import.js` during bulk. Download report when done.
+
+4. **Crawl**  
+   Use Importer Crawl tool: hostname + Get from robots.txt/sitemap or Crawl. Filter pathname if needed. Download report to get URL list for Bulk.
+
+## Success criteria
+
+- Landing page (and sampled URLs) import without errors and produce valid docx/HTML.
+- Structure matches intent: main content only, H1 first, metadata block present, key regions mapped to blocks (Hero, Cards, etc.).
+- Paths are sanitized and consistent (lowercase, hyphens, no .html).
+- Report includes any custom columns (e.g. title, list of images) for analysis.
+- Design tokens already applied so preview looks on-brand.
+
+## References
+
+- [AEM Importer (aem.live)](https://www.aem.live/developer/importer)
+- [Importer guidelines (helix-importer-ui)](https://github.com/adobe/helix-importer-ui/blob/main/importer-guidelines.md)
+- [Bulk importing (Experience League)](https://experienceleague.adobe.com/en/docs/experience-manager-learn/sites/document-authoring/how-to/bulk-importing-using-importer)
+- [Customizing the Importer](https://experienceleague.adobe.com/en/docs/experience-manager-learn/sites/document-authoring/how-to/customizing-importer)
+- [DA Import](https://da.live/apps/import), [Bulk](https://da.live/apps/bulk)
+- Project: `AGENTS.md`, `tools/library-pages.md`, `docs/aem-block-architecture.md`

--- a/tools/importer/README.md
+++ b/tools/importer/README.md
@@ -1,0 +1,69 @@
+# Importer tooling (DSG & bulk import)
+
+This folder holds the **AEM Importer** transformation and helpers for migrating [dickssportinggoods.com](https://www.dickssportinggoods.com/) (and similar retail sites) into AEM Edge Delivery / Document Authoring. Use it with the AEM bulk import tool from your local system or from [DA Import](https://da.live/apps/import) / [Bulk](https://da.live/apps/bulk).
+
+## Quick start
+
+1. **Design first**  
+   Run design extraction on the source site so `styles/styles.css` and fonts match the brand (see `.agents/skills/get-general-styling` or `design-system-extractor`).
+
+2. **Run the importer**  
+   From project root:
+   ```bash
+   npx -y @adobe/aem-cli import
+   ```
+   Or with auth headers:
+   ```bash
+   aem import --headers-file ./tools/importer/headers.json
+   ```
+   Choose **Document Authoring** (or AEM Authoring), then:
+   - **Workbench**: paste one URL (e.g. `https://www.dickssportinggoods.com/`), run import, tweak `import.js` and save to re-run.
+   - **Bulk**: paste many URLs (one per line), run import, download the report when done.
+
+3. **Tune selectors**  
+   Edit the config at the top of `import.js` (or `config.js`) to match the live site’s DOM (main, hero, header, footer). Iterate in Workbench before running bulk.
+
+## Files
+
+| File | Purpose |
+|------|--------|
+| **import.js** | Main entry for the AEM Importer. Exports `transform()` and `generateDocumentPath()`. Uses global `WebImporter` (provided by the importer UI). |
+| **config.js** | DSG selectors and EDS block names. Reference only; `import.js` inlines what it needs. |
+| **block-parser.js** | Helpers for building EDS block table shapes (Hero, Cards, Accordion, Columns). Use from Node or keep in sync with logic in `import.js`. |
+| **page-transformers.js** | Pure DOM transform helpers (get main, remove nodes, ensure H1, find hero, extract metadata). Reference / Node use. |
+| **MIGRATION-PLAN-DSG.md** | Full migration plan and phases. |
+| **README.md** | This file. |
+
+## Block mapping
+
+The importer turns blocks into HTML tables → Markdown → docx/HTML. Current mapping:
+
+- **Metadata**: from `<title>`, `og:description`, `og:image` → Metadata block (via `WebImporter.Blocks.getMetadataBlock`).
+- **Hero**: first hero-like section (image + heading) → Hero block table.
+- **Cards / Accordion / Columns**: extend `import.js` (or use `block-parser.js` cell shapes) and add selectors in config for product grids, FAQ, multi-column.
+
+See `block-parser.js` for the exact row/cell layout expected by EDS blocks.
+
+## Paths and report
+
+- Paths are sanitized (lowercase, hyphens, no `.html`) via `WebImporter.FileUtils.sanitizePath` or the fallback in `import.js`.
+- The default `transform()` returns one document per URL and adds a `report` object (e.g. `title`) so the Bulk download report gets extra columns.
+
+## Custom headers
+
+Create `tools/importer/headers.json` for auth or cookies:
+
+```json
+{
+  "Cookie": "your-session-cookie",
+  "Authorization": "Bearer token"
+}
+```
+
+Then run: `aem import --headers-file ./tools/importer/headers.json`.
+
+## References
+
+- [AEM Importer (aem.live)](https://www.aem.live/developer/importer)
+- [Importer guidelines (helix-importer-ui)](https://github.com/adobe/helix-importer-ui/blob/main/importer-guidelines.md)
+- [MIGRATION-PLAN-DSG.md](./MIGRATION-PLAN-DSG.md) in this folder

--- a/tools/importer/block-parser.js
+++ b/tools/importer/block-parser.js
@@ -1,0 +1,112 @@
+/**
+ * Block parser: build EDS block table structures for the AEM Importer.
+ *
+ * In the importer, blocks are represented as HTML tables. The first row is the
+ * block name; subsequent rows are content cells. The importer converts these to
+ * Markdown grid tables → docx/HTML. EDS then renders them via blocks/{name}/{name}.js.
+ *
+ * This module provides pure helpers that return cell arrays [row1, row2, ...]
+ * where each row is [cell1, cell2, ...]. Cells can be strings or DOM elements.
+ * Use with WebImporter.DOMUtils.createTable(cells, document) in import.js.
+ *
+ * Block shapes (align with blocks/ in this repo):
+ *
+ * - Hero:     [ ['Hero'], [heading, picture] ]
+ * - Cards:    [ ['Cards'], [...row1 cells...], [...row2 cells...], ... ]
+ * - Accordion:[ ['Accordion'], [label1, body1], [label2, body2], ... ]
+ * - Columns:  [ ['Columns'], [col1, col2, ...] ]
+ * - Metadata: use WebImporter.Blocks.getMetadataBlock(document, meta) in import.js
+ */
+
+/**
+ * Build Hero block rows: one row with block name, one row with heading + image.
+ * @param {Element} heading - h1 or h2 element
+ * @param {Element} image - img or picture element
+ * @returns {[string[], (Element|string)[]]}
+ */
+export function heroBlockRows(heading, image) {
+  return [
+    ['Hero'],
+    [heading || '', image || ''],
+  ];
+}
+
+/**
+ * Build Cards block rows: first row block name, then one row per card (e.g. image, title, description, link).
+ * @param {Element[]} cardElements - Array of card DOM elements (e.g. product cards)
+ * @param { (el: Element) => (Element|string)[] } [rowMapper] - Map each card to cell array (default: extract picture, headings, links)
+ * @returns { (string|Element)[][] }
+ */
+export function cardsBlockRows(cardElements, rowMapper = defaultCardRowMapper) {
+  const rows = [['Cards']];
+  cardElements.forEach((el) => {
+    rows.push(rowMapper(el));
+  });
+  return rows;
+}
+
+/**
+ * Default card row: [picture or img, title text, description text, link].
+ * @param {Element} el
+ * @returns {(Element|string)[]}
+ */
+function defaultCardRowMapper(el) {
+  const picture = el.querySelector('picture');
+  const img = el.querySelector('img');
+  const a = el.querySelector('a');
+  const h = el.querySelector('h2, h3, h4');
+  const desc = el.querySelector('p');
+  return [
+    picture || img || '',
+    h ? h.textContent.trim() : '',
+    desc ? desc.textContent.trim() : '',
+    a ? a : '',
+  ];
+}
+
+/**
+ * Build Accordion block rows: first row block name, then [label, body] per item.
+ * @param {Element[]} items - Array of item containers (each with label + body)
+ * @param { (el: Element) => [Element|string, Element|string] } [itemMapper] - Map each item to [label, body]
+ * @returns { (string|Element)[][] }
+ */
+export function accordionBlockRows(items, itemMapper = defaultAccordionItemMapper) {
+  const rows = [['Accordion']];
+  items.forEach((el) => {
+    const [label, body] = itemMapper(el);
+    rows.push([label, body]);
+  });
+  return rows;
+}
+
+/**
+ * Default accordion item: first child as label, rest as body.
+ * @param {Element} el
+ * @returns {[Element|string, Element|string]}
+ */
+function defaultAccordionItemMapper(el) {
+  const first = el.querySelector('dt, .label, h3, h4, [class*="label"]') || el.firstElementChild;
+  const rest = el.querySelector('dd, .body, [class*="content"]') || first?.nextElementSibling || el;
+  return [first || '', rest || ''];
+}
+
+/**
+ * Build Columns block rows: first row block name, one row with one cell per column.
+ * @param {Element[]} columnElements - Array of column containers
+ * @returns { (string|Element)[][] }
+ */
+export function columnsBlockRows(columnElements) {
+  const cells = columnElements.map((col) => col.cloneNode(true));
+  return [['Columns'], cells];
+}
+
+/**
+ * Metadata block: use WebImporter.Blocks.getMetadataBlock(document, meta) in import.js.
+ * Meta shape: { Title?: string, Description?: string, Image?: HTMLImageElement, ... }.
+ * This helper only documents the shape; actual creation is in import.js via WebImporter.
+ */
+export const METADATA_SHAPE = {
+  Title: 'string',
+  Description: 'string',
+  Image: 'HTMLImageElement',
+};

--- a/tools/importer/config.js
+++ b/tools/importer/config.js
@@ -1,0 +1,83 @@
+/**
+ * DSG (dickssportinggoods.com) importer configuration.
+ * Selectors and options for page transformers and block detection.
+ * Used by import.js (values inlined or kept in sync) and by any Node-based scripts.
+ *
+ * Tune these after inspecting the live site (header, main, hero, product grids, etc.).
+ */
+
+/** @type {Record<string, string | string[]>} */
+export const DSG_SELECTORS = {
+  // Main content container (prefer main, fallback to content wrapper)
+  main: 'main, [role="main"], .main-content, #main-content, .content-area',
+  // Strip from document before extracting main
+  remove: [
+    'header',
+    'footer',
+    'nav',
+    '.header',
+    '.footer',
+    '.navigation',
+    '.nav',
+    '[class*="cookie"]',
+    '[class*="banner"]',
+    '.skip-link',
+    'script',
+    'style',
+    'noscript',
+    'iframe',
+  ],
+  // Hero: first large visual block (image + heading)
+  hero: [
+    '.hero',
+    '[class*="hero"]',
+    '.banner',
+    '.homepage-hero',
+    'section:first-of-type picture',
+  ],
+  // Product or promo cards (for Cards block)
+  cardGrid: [
+    '.product-grid',
+    '.product-list',
+    '[class*="product-grid"]',
+    '[class*="card-grid"]',
+    '.cards',
+    '.promo-cards',
+  ],
+  // FAQ / expandable (for Accordion block)
+  accordion: [
+    '.faq',
+    '[class*="accordion"]',
+    '.expandable',
+    '[class*="collapse"]',
+  ],
+  // Multi-column layout
+  columns: ['.columns', '[class*="column-"]', '.multi-column'],
+};
+
+/** Default block names used when creating EDS block tables */
+export const EDS_BLOCK_NAMES = {
+  metadata: 'Metadata',
+  hero: 'Hero',
+  cards: 'Cards',
+  accordion: 'Accordion',
+  columns: 'Columns',
+  quote: 'Quote',
+  embed: 'Embed',
+};
+
+/** Path options: base path for imported docs, sanitize rules */
+export const PATH_OPTIONS = {
+  /** Replace source host with this in paths (optional) */
+  basePath: '',
+  /** Strip these path segments from URL pathname */
+  stripSegments: ['/en', '/us'],
+  /** Lowercase path segments */
+  lowercase: true,
+};
+
+export default {
+  DSG_SELECTORS,
+  EDS_BLOCK_NAMES,
+  PATH_OPTIONS,
+};

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -1,0 +1,217 @@
+/**
+ * AEM Importer transformation for dickssportinggoods.com (and configurable retail-style sites).
+ *
+ * Used by: AEM Importer (aem import / da.live Import & Bulk). Runs in browser; WebImporter
+ * is provided by the importer UI. Logic is aligned with tools/importer/block-parser.js and
+ * tools/importer/page-transformers.js — keep in sync when changing block mapping.
+ *
+ * @see https://github.com/adobe/helix-importer-ui/blob/main/importer-guidelines.md
+ * @see tools/importer/MIGRATION-PLAN-DSG.md
+ */
+
+/* global WebImporter */
+
+// --- Config (canonical selectors in tools/importer/config.js) ---
+const MAIN_SELECTOR = 'main, [role="main"], .main-content, #main-content, .content-area';
+const REMOVE_SELECTORS = [
+  'header',
+  'footer',
+  'nav',
+  '.header',
+  '.footer',
+  '.navigation',
+  '.nav',
+  '[class*="cookie"]',
+  '[class*="banner"]',
+  '.skip-link',
+  'script',
+  'style',
+  'noscript',
+  'iframe',
+];
+const HERO_SELECTORS = ['.hero', '[class*="hero"]', '.banner', '.homepage-hero'];
+
+/**
+ * Sanitize path for EDS: lowercase, latin, hyphens, no .html.
+ * Uses WebImporter.FileUtils.sanitizePath when available.
+ * @param {string} path
+ * @returns {string}
+ */
+function sanitizePath(path) {
+  if (typeof WebImporter !== 'undefined' && WebImporter.FileUtils && WebImporter.FileUtils.sanitizePath) {
+    return WebImporter.FileUtils.sanitizePath(path);
+  }
+  return path
+    .replace(/\/$/, '')
+    .replace(/\.html$/i, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9/-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '') || '/';
+}
+
+/**
+ * Generate document path from URL. One page → one path.
+ * @param {{ params?: { originalURL?: string }, url?: string }} opts
+ * @returns {string}
+ */
+function generateDocumentPath(opts) {
+  const url = opts.params?.originalURL || opts.url || '';
+  let pathname;
+  try {
+    pathname = new URL(url).pathname.replace(/\/$/, '').replace(/\.html$/i, '') || '/';
+  } catch (e) {
+    pathname = '/';
+  }
+  return sanitizePath(pathname);
+}
+
+/**
+ * Get main content root from document.
+ * @param {Document} document
+ * @returns {Element}
+ */
+function getMain(document) {
+  const main = document.querySelector(MAIN_SELECTOR);
+  return main || document.body;
+}
+
+/**
+ * Create metadata block and prepend to main. Uses WebImporter.Blocks.getMetadataBlock when available.
+ * @param {Element} main
+ * @param {Document} document
+ */
+function createMetadataBlock(main, document) {
+  const meta = {};
+  const titleEl = document.querySelector('title');
+  if (titleEl) meta.Title = titleEl.textContent.replace(/[\n\t]/g, '').trim();
+  const desc = document.querySelector('meta[name="description"], meta[property="og:description"]');
+  if (desc && desc.getAttribute('content')) meta.Description = desc.getAttribute('content');
+  const ogImage = document.querySelector('meta[property="og:image"]');
+  if (ogImage && ogImage.getAttribute('content')) {
+    const img = document.createElement('img');
+    img.src = ogImage.getAttribute('content');
+    meta.Image = img;
+  }
+  if (typeof WebImporter !== 'undefined' && WebImporter.Blocks && WebImporter.Blocks.getMetadataBlock) {
+    const block = WebImporter.Blocks.getMetadataBlock(document, meta);
+    if (block) main.prepend(block);
+  }
+}
+
+/**
+ * Optionally convert first hero-like section into a Hero block table and prepend to main.
+ * @param {Element} main
+ * @param {Document} document
+ */
+function ensureHeroBlock(main, document) {
+  let container = null;
+  let heading = null;
+  let image = null;
+  for (const sel of HERO_SELECTORS) {
+    try {
+      const el = main.querySelector(sel);
+      if (el) {
+        container = el;
+        heading = el.querySelector('h1, h2');
+        image = el.querySelector('picture img, img');
+        if (heading && image) break;
+      }
+    } catch (e) {
+      // skip
+    }
+  }
+  if (!container || !heading || !image) return;
+  if (typeof WebImporter !== 'undefined' && WebImporter.DOMUtils && WebImporter.DOMUtils.createTable) {
+    const cells = [
+      ['Hero'],
+      [heading, image],
+    ];
+    const table = WebImporter.DOMUtils.createTable(cells, document);
+    container.replaceWith(table);
+  }
+}
+
+/**
+ * Ensure first heading in main is H1.
+ * @param {Element} main
+ */
+function ensureFirstH1(main) {
+  const first = main.querySelector('h1, h2, h3, h4, h5, h6');
+  if (first && first.tagName !== 'H1') {
+    const h1 = document.createElement('h1');
+    h1.textContent = first.textContent;
+    first.replaceWith(h1);
+  }
+}
+
+/**
+ * Replace background images with img elements (so they appear in Markdown).
+ * @param {Element} main
+ * @param {Document} document
+ */
+function replaceBackgroundImages(main, document) {
+  if (typeof WebImporter !== 'undefined' && WebImporter.DOMUtils && WebImporter.DOMUtils.replaceBackgroundByImg) {
+    main.querySelectorAll('[style*="background-image"]').forEach((el) => {
+      try {
+        WebImporter.DOMUtils.replaceBackgroundByImg(el, document);
+      } catch (e) {
+        // skip
+      }
+    });
+  }
+}
+
+/**
+ * Single-page transform: cleanup and structure main for Markdown/docx.
+ * @param {{ document: Document, url?: string, params?: { originalURL?: string } }} opts
+ * @returns {{ element: Element, path: string, report?: Record<string, unknown> }}
+ */
+function transformOne(opts) {
+  const { document, params } = opts;
+  const main = getMain(document);
+
+  // Strip unwanted nodes (header, footer, nav, etc.)
+  if (typeof WebImporter !== 'undefined' && WebImporter.DOMUtils && WebImporter.DOMUtils.remove) {
+    WebImporter.DOMUtils.remove(main, REMOVE_SELECTORS);
+  } else {
+    REMOVE_SELECTORS.forEach((sel) => {
+      try {
+        main.querySelectorAll(sel).forEach((el) => el.remove());
+      } catch (e) {
+        // skip invalid selector
+      }
+    });
+  }
+
+  replaceBackgroundImages(main, document);
+  createMetadataBlock(main, document);
+  ensureHeroBlock(main, document);
+  ensureFirstH1(main);
+
+  const path = generateDocumentPath({ params, url: opts.url });
+
+  const report = {
+    title: document.title || '',
+  };
+
+  return { element: main, path, report };
+}
+
+/**
+ * Transform entry: one input URL → one output document (and optional report columns).
+ * Importer expects this export when using the single-doc flow.
+ */
+export default {
+  /**
+   * @param {{ document: Document, url?: string, html?: string, params?: { originalURL?: string } }} opts
+   * @returns {Array<{ element: Element, path: string, report?: Record<string, unknown> }>}
+   */
+  transform(opts) {
+    return [transformOne(opts)];
+  },
+
+  generateDocumentPath(opts) {
+    return generateDocumentPath(opts);
+  },
+};

--- a/tools/importer/page-transformers.js
+++ b/tools/importer/page-transformers.js
@@ -1,0 +1,105 @@
+/**
+ * Page transformers: pure DOM operations for import preprocessing.
+ *
+ * These functions take a document (or root element) and optionally a config object,
+ * and mutate or derive a cleaned/main content root. They do not use WebImporter;
+ * use them from import.js (logic inlined there) or from a Node script with jsdom.
+ *
+ * When used in the AEM Importer, the actual DOM is the one inside the iframe;
+ * WebImporter.DOMUtils.remove(main, selectors) is the runtime way to strip nodes.
+ * The logic here mirrors that for reference and for non-browser use.
+ */
+
+/**
+ * Get the main content container from the document.
+ * @param {Document} document
+ * @param {string | string[]} mainSelectors - Comma-separated or array of selectors
+ * @returns {Element | null}
+ */
+export function getMainRoot(document, mainSelectors = 'main, [role="main"], .main-content') {
+  const selectors = Array.isArray(mainSelectors) ? mainSelectors.join(', ') : mainSelectors;
+  return document.querySelector(selectors) || document.body;
+}
+
+/**
+ * Remove elements matching selectors from a root (mutates root).
+ * @param {Element} root
+ * @param {string[]} selectors
+ */
+export function removeFromRoot(root, selectors) {
+  selectors.forEach((sel) => {
+    try {
+      root.querySelectorAll(sel).forEach((el) => el.remove());
+    } catch (e) {
+      // invalid selector
+    }
+  });
+}
+
+/**
+ * Ensure the first heading in root is H1 (demote others if needed).
+ * @param {Element} root
+ */
+export function ensureFirstHeadingIsH1(root) {
+  const firstHeading = root.querySelector('h1, h2, h3, h4, h5, h6');
+  if (firstHeading && firstHeading.tagName !== 'H1') {
+    firstHeading.outerHTML = `<h1>${firstHeading.textContent}</h1>`;
+  }
+}
+
+/**
+ * Find first hero-like section (picture + heading).
+ * @param {Element} root
+ * @param {string[]} heroSelectors
+ * @returns {{ heading: Element | null, image: Element | null, container: Element | null }}
+ */
+export function findHero(root, heroSelectors = ['.hero', '[class*="hero"]', '.banner']) {
+  for (const sel of heroSelectors) {
+    try {
+      const container = root.querySelector(sel);
+      if (container) {
+        const heading = container.querySelector('h1, h2');
+        const picture = container.querySelector('picture');
+        const img = container.querySelector('img');
+        return {
+          heading: heading || null,
+          image: picture || img || null,
+          container,
+        };
+      }
+    } catch (e) {
+      // skip invalid selector
+    }
+  }
+  // Fallback: first section with picture + heading
+  const section = root.querySelector('section, [class*="section"]');
+  if (section) {
+    const heading = section.querySelector('h1, h2');
+    const picture = section.querySelector('picture');
+    const img = section.querySelector('img');
+    if (heading && (picture || img)) {
+      return {
+        heading,
+        image: picture || img,
+        container: section,
+      };
+    }
+  }
+  return { heading: null, image: null, container: null };
+}
+
+/**
+ * Extract metadata from document head for Metadata block.
+ * @param {Document} document
+ * @returns {{ Title?: string, Description?: string, Image?: string }}
+ */
+export function extractMetadata(document) {
+  const meta = {};
+  const titleEl = document.querySelector('title');
+  if (titleEl) meta.Title = titleEl.textContent.replace(/[\n\t]/g, '').trim();
+  const desc = document.querySelector('meta[name="description"], meta[property="og:description"]');
+  if (desc && desc.getAttribute('content')) meta.Description = desc.getAttribute('content');
+  const ogImage = document.querySelector('meta[property="og:image"]');
+  if (ogImage && ogImage.getAttribute('content')) meta.Image = ogImage.getAttribute('content');
+  return meta;
+}


### PR DESCRIPTION
- Updated package dependencies: upgraded eslint-plugin-sonarjs to version 4.0.2 and adjusted related dependencies.
- Introduced new files for the AEM Importer, including block parser, configuration, and page transformers to facilitate the migration process.
- Added a comprehensive migration plan document outlining the steps for importing content from dickssportinggoods.com into AEM.
- Implemented core transformation logic in import.js to handle document structure and metadata extraction.
- Created README for usage instructions and file purposes within the importer tooling.

<!-- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->
<!-- Feel free to delete options that are not relevant to your PR. -->

## Issue

Fixes #IssueID

## Description of what the PR is changing, including screenshots for clarity if needed.

**New**

- 

**Changed**

- 

**Removed**

- 


## Test URLs and instructions -- There can be more than 1 set

> If applicable, also describe how the PR reviewer can verify your expected changes, including anything that should NOT change.

- Before: https://main--ise-boilerplate--aemdemos.aem.page/
- After: https://BranchName--ise-boilerplate--aemdemos.aem.page/